### PR TITLE
Add IRC link as discussed

### DIFF
--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -15,6 +15,9 @@
       <div class="col-sm-4 text-right">
         <ul>
           <li>
+            <a href="ircs://chat.freenode.net:6697/freenode-jobs"><i class="fa fa-comments"></i></a>
+          </li>
+          <li>
             <a href="https://www.facebook.com/freenode-366911233325305/"><i class="fa fa-facebook"></i></a>
           </li>
           <li>


### PR DESCRIPTION
Adds an IRC link to the footer since people asked for it. 
As there is no official IRC icon in font-awesome (which I consider a bug), I used the one that makes the most sense.

Downside: it's <a> with a font-awesome thing, so the channel name is still not terribly obvious (unless you hover it and can read ircs links), but then I don't think it has to be.